### PR TITLE
Connect homepage service

### DIFF
--- a/.ebextensions/yarn.config
+++ b/.ebextensions/yarn.config
@@ -1,0 +1,13 @@
+# Source: https://serverfault.com/questions/840628/how-do-i-get-yarn-installed-on-elastic-beanstalk
+commands:
+  01_install_node:
+    command: |
+      sudo curl --silent --location https://rpm.nodesource.com/setup_8.x | sudo bash -
+      sudo yum -y install nodejs
+
+  02_install_yarn:
+    # don't run the command if yarn is already installed (file /usr/bin/yarn exists)
+    test: '[ ! -f /usr/bin/yarn ] && echo "Yarn not found, installing..."'
+    command: |
+      sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
+      sudo yum -y install yarn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,4 @@ jobs:
         version_label: ${{ steps.get_version.outputs.VERSION }}
         region: us-east-1
         deployment_package: deploy.zip
+        use_existing_version_if_available: true

--- a/README.md
+++ b/README.md
@@ -1,17 +1,45 @@
-# Group Management system (working name)
+# Group Web UI
 A system for organizing communities, with features such as calendars,
 announcements, and home pages. Currently being developed by Team C for
 [CS 497S: Scalable Web Systems][1], taught by Professor Tim Richards at
 UMass Amherst.
 
-## Components
-Consult the README files in each component's directory for build
-instructions.
+This repository contains the web user interface for this system.
 
-- [Desktop Web UI](web-app)
-    - The frontend for the desktop web app.
-    - Requires the API to be running in order to function correctly.
-- [API](api)
-    - The backend for the desktop web app.
+## Development
+To build the service for development, use the following instructions:
+
+1. Run `./scripts/build-for-server.sh`
+2. Run `pipenv install`
+3. Set environment variables:
+    - `export FLASK_APP=server`
+    - `export FLASK_ENV=development`
+    - `export GROUP_SERVER_HOST=http://<hostname>:<port>`
+    - `export EVENT_SERVER_HOST=http://<hostname>:<port>`
+    - `export IMAGE_SERVER_HOST=http://<hostname>:<port>`
+    - If the latter three variables are not set, the server defaults to
+    http://localhost:5001, http://localhost:5002, and
+    http://localhost:5003, respectively.
+4. Run `pipenv run flask run`
+
+The build-for-server script must be re-run each time the client is
+edited in order for Flask to serve it. Alternatively, `cd` into
+[client](client) and run `yarn serve` to refresh the client after each
+change. This method does not allow the client to connect to the server.
+
+## Design and Implementation
+This web app is designed according to the backends for frontends
+pattern described by Sam Newman in *Building Microservices*. The server
+sends a single-page [Vue.js](https://vuejs.org/) app and also hosts an
+API to service requests from the client.
+
+The server is developed with [Flask](https://flask.palletsprojects.com/)
+and uses the [Requests](https://requests.readthedocs.io/) library to
+send requests to upstream services. The data from the responses is then
+repackaged and sent along to the client. In this way, the backend can
+organize data in a more convenient format for the client.
+
+## API
+Documentation for the backend's API is [here](server/README.md).
 
 [1]: https://sites.google.com/cs.umass.edu/compsci-497s-f20-submissions

--- a/client/src/components/EventTable.vue
+++ b/client/src/components/EventTable.vue
@@ -42,9 +42,7 @@ export default {
     },
     methods: {
         async getEvents() {
-            const baseURL = 'http://localhost:5000'
-            const resp = await fetch(
-                baseURL + '/api/group/' + this.groupID + '/events');
+            const resp = await fetch('/api/group/' + this.groupID + '/events');
             const json = await resp.json();
             this.events = json.events.slice();
         }

--- a/client/src/components/GroupHome.vue
+++ b/client/src/components/GroupHome.vue
@@ -6,14 +6,31 @@
                 id="group-icon"
             >
             <div id="group-welcome">
-                <h1>{{ name }}</h1>
-                <p>{{ welcome }}</p>
+                <form v-if="editing" v-on:submit="submitEdit">
+                    <section>
+                        <input v-model="name">
+                    </section>
+                    <section>
+                        <textarea v-model="welcome"></textarea>
+                    </section>
+                </form>
+                <div v-else>
+                    <h1>{{ name }}</h1>
+                    <p>{{ welcome }}</p>
+                </div>
             </div>
         </div>
         <div id="group-about">
             <h2>About</h2>
-            <p>{{ about }}</p>
+            <form v-if="editing">
+                <textarea v-model="about"></textarea>
+            </form>
+            <div v-else>
+                <p>{{ about }}</p>
+            </div>
         </div>
+        <button v-if="editing" v-on:click="submitEdit">Save</button>
+        <button v-else v-on:click="editing = true">Edit</button>
     </div>
 </template>
 
@@ -28,7 +45,8 @@ export default {
             name: '',
             welcome: '',
             about: '',
-            icon: ''
+            icon: '',
+            editing: false,
         };
     },
     beforeMount() {
@@ -42,7 +60,22 @@ export default {
             this.welcome = json.welcome;
             this.about = json.about;
             this.icon = json.icon;
-        }
+        },
+        async submitEdit() {
+            let data = {
+                'name' : this.name,
+                'welcome' : this.welcome,
+                'about' : this.about,
+            };
+            await fetch('/api/group/' + this.groupID + '/home', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+            });
+            this.editing = false;
+        },
     }
 }
 </script>

--- a/client/src/components/GroupHome.vue
+++ b/client/src/components/GroupHome.vue
@@ -36,9 +36,7 @@ export default {
     },
     methods: {
         async getHome() {
-            const baseURL = 'http://localhost:5000'
-            const resp = await fetch(
-                baseURL + '/api/group/' + this.groupID + '/home');
+            const resp = await fetch('/api/group/' + this.groupID + '/home');
             const json = await resp.json();
             this.name = json.name;
             this.welcome = json.welcome;

--- a/server/README.md
+++ b/server/README.md
@@ -4,13 +4,20 @@ This API serves as the gateway to the backend for the desktop web UI.
 
 ## Build
 
-1. `cd` into this directory.
-2. Run `pipenv install` to generate a Python virtual environment from
-the [Pipfile](Pipfile).
-3. Once the virtual environment has been generated, run
-`pipenv run flask run` to launch the Flask development server.
+See instructions under "Development" [here](../README.md).
 
 ## API requests
+
+### Check service connections
+Sent a GET request to `/api/status`. The response contains a JSON
+object with the following boolean attributes indicating whether a
+connection has been established with each of the upstream services.
+
+| Attribute | Type      | Description      |
+| --------- | --------- | ---------------- |
+| home      | `boolean` | Homepage service |
+| event     | `boolean` | Events service   |
+| image     | `boolean` | Images service   |
 
 ### Read events
 
@@ -31,7 +38,21 @@ a JSON object with the following attributes.
 
 | Attribute | Type     | Description             |
 | --------- | -------- | ----------------------- |
+| id        | `number` | Group ID                |
 | name      | `string` | Group name              |
 | welcome   | `string` | Welcome message         |
 | about     | `string` | About text              |
 | icon      | `string` | URL to the group's icon |
+
+### Edit group homepages
+
+Send a PUT request to `/api/group/:group_id:/home` with the
+`Content-Type: application/json` header and a JSON object in the body.
+The JSON should contain any of the following attributes to edit the
+corresponding field.
+
+| Attribute | Type     | Description             |
+| --------- | -------- | ----------------------- |
+| name      | `string` | Group name              |
+| welcome   | `string` | Welcome message         |
+| about     | `string` | About text              |

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -11,6 +11,15 @@ app = Flask(__name__)
 app.config.from_object('server.config')
 
 
+def check_connection(url):
+    """Return True if a connection can be established with url, return
+    False otherwise."""
+    try:
+        return requests.get(url).ok
+    except requests.ConnectionError:
+        return False
+
+
 @app.route('/')
 def send_homepage():
     """Send index.html from the built Vue app."""
@@ -39,6 +48,19 @@ def send_favicon():
 def hello_world():
     """A welcome message to verify a connection to the API."""
     return 'Welcome to the API!'
+
+
+@app.route('/api/status')
+def service_connections():
+    """Return a dict from service names to booleans indicating whether
+    a connection can be established with their hosts."""
+    urls = {
+        'home'  : app.config['GROUP_SERVER_HOST'] + '/api/homepage/docs',
+        'event' : app.config['EVENT_SERVER_HOST'] + '/',
+        'image' : app.config['IMAGE_SERVER_HOST'] + '/images/docs',
+    }
+    statuses = {x: check_connection(y) for (x,y) in urls.items()}
+    return jsonify(statuses)
 
 
 @app.route('/api/group/<group_id>/events')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -4,7 +4,8 @@ import random
 import string
 from datetime import datetime, timedelta
 import requests
-from flask import Flask, jsonify, make_response, send_from_directory, url_for
+from flask import (abort, Flask, jsonify, make_response, request,
+    send_from_directory, url_for)
 
 
 app = Flask(__name__)
@@ -85,3 +86,20 @@ def get_group_home(group_id):
         'about' : upstream.get('about_section'),
     }
     return jsonify(downstream)
+
+
+@app.route('/api/group/<group_id>/home', methods=['PUT'])
+def edit_group_home(group_id):
+    """Update the group service."""
+    data = {}
+    if request.json is None:
+        abort(400)
+    if 'name' in request.json:
+        data['group_name'] = request.json['name']
+    if 'welcome' in request.json:
+        data['welcome_message'] = request.json['welcome']
+    if 'about' in request.json:
+        data['about_section'] = request.json['about']
+    request_url = app.config['GROUP_SERVER_HOST'] + '/api/homepage/' + group_id
+    resp = requests.patch(request_url, json=data)
+    return 'passed', resp.status_code

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -47,17 +47,19 @@ def get_events(group_id):
     time."""
     request_url = app.config['EVENT_SERVER_HOST'] + '/group/' + group_id
     group_events = requests.get(request_url).json()
-    response = make_response(group_events)
-    response.headers['Access-Control-Allow-Origin'] = '*'
-    return response
+    return jsonify(group_events)
 
 
 @app.route('/api/group/<group_id>/home')
 def get_group_home(group_id):
     """Return a JSON object containing the group's name, welcome
     message, about text, and a URL to its icon."""
-    request_url = app.config['GROUP_SERVER_HOST'] + '/group/' + group_id
-    group_info = requests.get(request_url).json()
-    response = make_response(group_info)
-    response.headers['Access-Control-Allow-Origin'] = '*'
-    return response
+    request_url = app.config['GROUP_SERVER_HOST'] + '/api/homepage/' + group_id
+    upstream = requests.get(request_url).json()
+    downstream = {
+        'id' : group_id,
+        'name' : upstream.get('group_name'),
+        'welcome' : upstream.get('welcome_message'),
+        'about' : upstream.get('about_section'),
+    }
+    return jsonify(downstream)


### PR DESCRIPTION
Connects the backend to the homepage service and adds the ability to edit homepage information in the UI. The hostnames for the other services can be set with environment variables. Documentation has been updated to describe this service in more detail and include API information for the new endpoints.

CI tests are broken due to the change in connecting with upstream services. These tests will be fixed in a future update.